### PR TITLE
feat: add server testing commands

### DIFF
--- a/cmd/ezoidc/main.go
+++ b/cmd/ezoidc/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/ezoidc/ezoidc/pkg/client"
+	"github.com/ezoidc/ezoidc/pkg/models"
 	"github.com/ezoidc/ezoidc/pkg/static"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -54,9 +54,7 @@ var variablesJsonCmd = &cobra.Command{
 			return err
 		}
 
-		encoder := json.NewEncoder(os.Stdout)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(variablesResponse)
+		return models.JSONEncoder(os.Stdout).Encode(variablesResponse)
 	},
 }
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -46,8 +46,8 @@ type EngineInput struct {
 }
 
 type ReadResponse struct {
-	Variables []models.Variable
-	Allowed   map[string]string
+	Variables []models.Variable `json:"variables,omitempty"`
+	Allowed   map[string]string `json:"allowed"`
 }
 
 // Create a new policy engine using default variable resolvers

--- a/pkg/models/json.go
+++ b/pkg/models/json.go
@@ -1,0 +1,12 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func JSONEncoder(w io.Writer) *json.Encoder {
+	e := json.NewEncoder(w)
+	e.SetIndent("", "  ")
+	return e
+}


### PR DESCRIPTION
Add a `test` command to the server to evaluate the server's configuration against a set of claims. 
 
```sh
$ ezoidc-server test variables --claims '{"iss": "https://token.actions.githubusercontent.com"}'
{
  "allowed": {
    "key": "internal",
    "gh_token": "read"
  }
}
```