### PR TITLE
feat: add user-provided params to the policy eval

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           persist-credentials: false
-      - uses: azure/setup-helm@73f3a866be3c4a3b63ce5f6dc59a1c5a992f4a2c # v4
+      - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4
       - name: Login to GitHub Container Registry
         env:
           ACTOR: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -25,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
-      - uses: StyraInc/setup-regal@b01ac9f4bece22d1066ed2ca8f91a3e89b57013f # v1
+      - uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1
         with:
           version: 0.29.0
       - name: golangci-lint

--- a/.github/workflows/ko.yml
+++ b/.github/workflows/ko.yml
@@ -23,5 +23,5 @@ jobs:
           cache: false
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
         with:
-          version: tip # --image-annotation
+          version: v0.17.1
       - run: make ko.push

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint: lint.go lint.rego
 
 lint.go: golangci-lint ?= golangci-lint
 lint.go:
-	$(golangci-lint) run
+	$(golangci-lint) run --timeout=10m
 
 lint.rego: regal ?= regal
 lint.rego:
@@ -55,7 +55,7 @@ ko.push:
 	--sbom "none" \
 	$(foreach label,$(OCI_LABELS),--image-annotation $(label) --image-label $(label)) \
 	--tags latest$(foreach tag,$(GIT_VERSION),,$(tag)) \
-	./ko/server ./ko/cli 
+	./ko/server ./ko/cli
 
 helm.push:
 	helm package ./chart

--- a/cmd/ezoidc-server/main.go
+++ b/cmd/ezoidc-server/main.go
@@ -57,13 +57,19 @@ var startCmd = &cobra.Command{
 }
 
 var testClaims string
+var testParams string
 var testVariablesCmd = &cobra.Command{
 	Use:   "variables",
 	Short: "Allowed variables given the provided claims",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var res engine.ReadResponse
 		var claims map[string]any
+		var params map[string]any
 		err := json.Unmarshal([]byte(testClaims), &claims)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal([]byte(testParams), &params)
 		if err != nil {
 			return err
 		}
@@ -80,7 +86,10 @@ var testVariablesCmd = &cobra.Command{
 			return err
 		}
 
-		allowed, err := eng.Allowed(ctx, claims)
+		allowed, err := eng.AllowedVariables(ctx, &engine.ReadRequest{
+			Claims: claims,
+			Params: params,
+		})
 		if err != nil {
 			return err
 		}
@@ -110,6 +119,7 @@ func main() {
 	testCmd.AddCommand(testVariablesCmd)
 
 	testVariablesCmd.Flags().StringVar(&testClaims, "claims", "{}", "Claims to use for the test")
+	testVariablesCmd.Flags().StringVar(&testParams, "params", "{}", "Params to use for the test")
 
 	startCmd.Flags().StringVarP(&configPath,
 		"config", "c", "config.yaml",

--- a/cmd/ezoidc/main.go
+++ b/cmd/ezoidc/main.go
@@ -156,7 +156,7 @@ func main() {
 		"Override the host address of the server (env: EZOIDC_HOST)")
 
 	state.paramsList = variablesCmd.PersistentFlags().
-		StringArrayP("param", "p", nil, "Provide a single parameter")
+		StringArrayP("param", "p", nil, "Parameter name=value to include in the request")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -26,22 +26,20 @@ func NewAPIClient(client HTTPClient, baseURL string) *APIClient {
 	}
 }
 
-func (c *APIClient) GetVariables(ctx context.Context, token string) (*models.VariablesResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", c.BaseURL+"/ezoidc/1.0/variables", nil)
+func (c *APIClient) GetVariables(ctx context.Context, r *models.VariablesRequest) (*models.VariablesResponse, error) {
+	body, _ := json.Marshal(r)
+	req, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/ezoidc/1.0/variables", strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+r.Token)
 	resp, err := c.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		var body struct {
-			Error  string `json:"error"`
-			Reason string `json:"reason"`
-		}
+		var body models.ErrorResponse
 		err = json.NewDecoder(resp.Body).Decode(&body)
 		if err != nil {
 			return nil, err

--- a/pkg/engine/ezoidc.rego
+++ b/pkg/engine/ezoidc.rego
@@ -15,6 +15,8 @@ issuers[key] := data.issuers[key]
 
 claims[key] := input.claims[key]
 
+params[key] := input.params[key]
+
 read(name) := var.value.string if {
 	some var in input.variables
 	var.name == name

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -5,6 +5,11 @@ type MetadataResponse struct {
 	APIVersion string `json:"api_version"`
 }
 
+type VariablesRequest struct {
+	Token  string         `json:"-"`
+	Params map[string]any `json:"params"`
+}
+
 type VariablesResponse struct {
 	Variables []Variable `json:"variables"`
 }
@@ -12,8 +17,4 @@ type VariablesResponse struct {
 type ErrorResponse struct {
 	Error  string `json:"error"`
 	Reason string `json:"reason,omitempty"`
-}
-
-type VariablesRequest struct {
-	Params map[string]any `json:"params"`
 }

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -13,3 +13,7 @@ type ErrorResponse struct {
 	Error  string `json:"error"`
 	Reason string `json:"reason,omitempty"`
 }
+
+type VariablesRequest struct {
+	Params map[string]any `json:"params"`
+}

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -41,6 +41,11 @@ func NewAPI(eng *engine.Engine) *API {
 				})
 				return
 			}
+			params := []string{}
+			for k := range body.Params {
+				params = append(params, k)
+			}
+			c.Set("params", params)
 		}
 
 		claims := c.GetStringMap("claims")
@@ -53,6 +58,7 @@ func NewAPI(eng *engine.Engine) *API {
 			return
 		}
 		c.Set("allowed", response.Allowed)
+
 		c.JSON(200, models.VariablesResponse{Variables: response.Variables})
 	})
 
@@ -93,6 +99,11 @@ func jsonLogs() gin.HandlerFunc {
 				iss, _ := claims["iss"].(string)
 				line = line.Str("sub", sub).Str("iss", iss)
 			}
+
+			if params, ok := params.Keys["params"].([]string); ok {
+				line = line.Strs("params", params)
+			}
+
 			line.Send()
 			return ""
 		},


### PR DESCRIPTION
- Parameters can be set in the CLI `ezoidc variables env --param key=value`
- /ezoidc/1.0/variables accepts POST request with a JSON body
- Policies access request parameters in `params`
- Breaking: 
  - `pkg/client`: changed arguments of `GetVariables`
  - `pkg/engine`:  replace `Allowed`, `Read` methods with `AllowedVariables`, `ReadVariables`
